### PR TITLE
Added explicit end to the DHCP packet

### DIFF
--- a/dhcpsnoop/dhcpsnoop.py
+++ b/dhcpsnoop/dhcpsnoop.py
@@ -203,7 +203,7 @@ def make_dhcp_request(pktface):
         IP(src="0.0.0.0",dst="255.255.255.255")/
         UDP(sport=68,dport=67)/
         BOOTP(chaddr=hw)/
-        DHCP(options=[("message-type","discover")]),count=3, iface=pktface)
+        DHCP(options=[("message-type","discover"), "end"]),count=3, iface=pktface)
 
 def dhcp_callback(pkt):
     """


### PR DESCRIPTION
This change brings the construction of the packet into line with the example in the scapy documentation, (http://www.secdev.org/projects/scapy/doc/usage.html)

It also improves compatibility with the routers I have been testing this with.